### PR TITLE
Added UserCategory in HelpForRealm for tests with this

### DIFF
--- a/project/app/src/test/java/com/nexte/nexte/HelpForRealm.kt
+++ b/project/app/src/test/java/com/nexte/nexte/HelpForRealm.kt
@@ -3,6 +3,7 @@ package com.nexte.nexte
 import android.content.Context
 import com.nexte.nexte.Entities.Story.StoryRealm
 import com.nexte.nexte.Entities.User.User
+import com.nexte.nexte.Entities.User.UserCategory.UserCategoryRealm
 import com.nexte.nexte.Entities.User.UserRealm
 import com.nexte.nexte.FeedScene.FeedFragment
 import io.realm.Realm
@@ -77,6 +78,7 @@ open class HelpForRealm {
         val userResults: RealmResults<UserRealm> = mock()
 
         this.setUpRealm()
+        this.setUpWithUserCategory()
 
         val userQuery: RealmQuery<UserRealm> = mock()
 
@@ -84,6 +86,23 @@ open class HelpForRealm {
         PowerMockito.`when`(userQuery.equalTo(Matchers.anyString(), Matchers.anyString())).thenReturn(userQuery)
         PowerMockito.`when`(userQuery.findFirst()).thenReturn(userList[0])
         PowerMockito.`when`(userQuery.findAll()).thenReturn(userResults)
+    }
+
+    fun setUpWithUserCategory() {
+
+        val id = "1"
+        val name = "Primeira Classe"
+        val uc1 = UserCategoryRealm(id, name)
+
+        val userCategoryList = Arrays.asList(uc1)
+        val userCategoryResults: RealmResults<UserCategoryRealm> = mock()
+
+        val userCategoryQuery: RealmQuery<UserCategoryRealm> = mock()
+
+        PowerMockito.`when`(mockRealm!!.where(UserCategoryRealm::class.java)).thenReturn(userCategoryQuery)
+        PowerMockito.`when`(userCategoryQuery.equalTo(Matchers.anyString(), Matchers.anyString())).thenReturn(userCategoryQuery)
+        PowerMockito.`when`(userCategoryQuery.findFirst()).thenReturn(userCategoryList[0])
+        PowerMockito.`when`(userCategoryQuery.findAll()).thenReturn(userCategoryResults)
     }
 
     @Test


### PR DESCRIPTION
## Descrição
Esse Hotfix adiciona o UserCategory no HelpForRealm para conseguir simular os testes quando necessário o uso da UserCategory.

### Qual tipo de mudança o Pull Request introduz?
* Adiciona UserCategory no mock do Realm.

### Qual é o comportanto atual?
* Não existe UserCategory no mock do Realm.

### Qual é o novo comportamento?
* UserCategory está no mock do Realm.

### Quais as issues o Pull Request finaliza?
Não se aplica.

### _Uso do avaliador_
- [ ] Mensagens de commits seguem a guideline proposta;
- [ ] Os testes foram adicionados mantendo ou aumentando a cobertura de testes;
- [ ] Documentos necessários foram atualizados ou adicionados;