### PR TITLE
Feature/484

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,4 +90,4 @@ pages:
     - Testes de Usabilidade: Testes/TestesUsabilidade.md
   - Post Mortem:
     - Post Mortem - Release 1: PostMortem/PostMortemRelease1.md
-    - Post Mortem Release 2 + Fechamento do Projeto: PostMortem/PostMortemRelease2-FechamentoDoProjeto.md
+    - Post Mortem Release 2 + Fechamento do Projeto: PostMortemRelease2-FechamentoDoProjeto.md

--- a/project/app/src/main/java/com/nexte/nexte/CommentsScene/CommentsFragment.kt
+++ b/project/app/src/main/java/com/nexte/nexte/CommentsScene/CommentsFragment.kt
@@ -97,6 +97,12 @@ class CommentsFragment : Fragment(), CommentsDisplayLogic {
 
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        this.activity.fragmentManager.popBackStack()
+
+    }
+
     /**
      * This function send the request built with the identified story
      */

--- a/project/app/src/main/java/com/nexte/nexte/EditProfileScene/EditProfileFragment.kt
+++ b/project/app/src/main/java/com/nexte/nexte/EditProfileScene/EditProfileFragment.kt
@@ -114,6 +114,11 @@ class EditProfileFragment : Fragment(),
         return newView
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        this.activity.fragmentManager.popBackStack()
+
+    }
 
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
         this.createGetProfileRequest()

--- a/project/app/src/main/java/com/nexte/nexte/FeedScene/FeedFragment.kt
+++ b/project/app/src/main/java/com/nexte/nexte/FeedScene/FeedFragment.kt
@@ -37,6 +37,8 @@ class FeedFragment : Fragment(), FeedDisplayLogic {
     var feedRecyclerView : RecyclerView? = null
     var storyManager: StoryManager? = null
     var userManager: UserManager? = null
+    var feedCommentsFragment: CommentsFragment? = null
+    var feedLikesFragment: LikeListFragment? = null
 
     fun getInstance() : FeedFragment {
         return FeedFragment()
@@ -56,6 +58,32 @@ class FeedFragment : Fragment(), FeedDisplayLogic {
 
         this.createGetActivitiesRequest()
         return newView
+    }
+
+    /**
+     *
+     */
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if(feedCommentsFragment == null){
+            feedCommentsFragment = CommentsFragment()
+        }
+        if(feedCommentsFragment?.isVisible!!){
+            feedCommentsFragment?.onDestroy()
+            feedCommentsFragment?.onDetach()
+            feedCommentsFragment?.onDestroyView()
+        }
+
+        if(feedLikesFragment == null){
+            feedLikesFragment= LikeListFragment()
+        }
+        if(feedLikesFragment?.isVisible!!){
+            feedLikesFragment?.onDestroy()
+            feedLikesFragment?.onDetach()
+            feedLikesFragment?.onDestroyView()
+        }
+
+
     }
 
 
@@ -89,6 +117,7 @@ class FeedFragment : Fragment(), FeedDisplayLogic {
      */
     private fun goToLikesList(identifier: String) {
         val likeListFragment = LikeListFragment().getInstance(identifier)
+        feedLikesFragment = likeListFragment
         val fragmentManager = activity?.fragmentManager
         val fragmentTransaction = fragmentManager?.beginTransaction()
         fragmentTransaction?.replace(R.id.main_frame_layout, likeListFragment, "like")
@@ -100,6 +129,7 @@ class FeedFragment : Fragment(), FeedDisplayLogic {
 
     private fun goToCommentsList(identifier: String) {
         val commentsFragment = CommentsFragment().getInstance(identifier)
+        feedCommentsFragment = commentsFragment
         val fragmentManager = activity?.fragmentManager
         val fragmentTransaction = fragmentManager?.beginTransaction()
         fragmentTransaction?.replace(R.id.main_frame_layout, commentsFragment, "comments")

--- a/project/app/src/main/java/com/nexte/nexte/LikeListScene/LikeListFragment.kt
+++ b/project/app/src/main/java/com/nexte/nexte/LikeListScene/LikeListFragment.kt
@@ -78,6 +78,12 @@ class LikeListFragment : Fragment(), LikeListDisplayLogic {
         return newView
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        this.activity.fragmentManager.popBackStack()
+
+    }
+
     /**
      * Method responsible for creating the fetch data to list request and passing it to the interactor
      */

--- a/project/app/src/main/java/com/nexte/nexte/ShowProfileScene/ShowProfileFragment.kt
+++ b/project/app/src/main/java/com/nexte/nexte/ShowProfileScene/ShowProfileFragment.kt
@@ -37,7 +37,7 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.provider.ContactsContract
-import android.util.Log
+
 import android.widget.Toast
 import com.nexte.nexte.UserType
 import com.squareup.picasso.Picasso

--- a/project/app/src/main/java/com/nexte/nexte/ShowProfileScene/ShowProfileFragment.kt
+++ b/project/app/src/main/java/com/nexte/nexte/ShowProfileScene/ShowProfileFragment.kt
@@ -37,6 +37,7 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.provider.ContactsContract
+import android.util.Log
 import android.widget.Toast
 import com.nexte.nexte.UserType
 import com.squareup.picasso.Picasso
@@ -161,6 +162,16 @@ class ShowProfileFragment : Fragment(), ShowProfileDisplayLogic {
             this.numb_games.text = (player.wins + player.loses).toString()
             this.numb_victory.text = player.wins.toString()
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if(editProfileFragment.isVisible){
+            editProfileFragment.onDestroy()
+            editProfileFragment.onDetach()
+            editProfileFragment.onDestroyView()
+        }
+
     }
 
     /**


### PR DESCRIPTION
## Descrição
Essa issue conserta o bug da transição de fragmentos das cenas de editar perfil, curtir e comentar partidas. 

### Qual é o comportanto atual?
Após editar o perfil ou abrir as cenas de lista de curtidas ou comentários, quando são convocados os outros fragments da nav bar, essas cenas são setadas novamente gerando um bug.

### Qual é o novo comportamento?
Após a conclusão de uma ação no fragment, ele será encerrado permanentemente até que ele seja chamado novamente.

### Quais as issues o Pull Request finaliza?
#484 

### _Uso do avaliador_
- [ ] Mensagens de commits seguem a guideline proposta.